### PR TITLE
Fix for CWE-190: Integer Overflow or Wraparound

### DIFF
--- a/lib/libwasm.c
+++ b/lib/libwasm.c
@@ -412,7 +412,11 @@ int Wasm_ParseExportSection(uint8_t* buffer, uint32_t buffer_size, WasmSection* 
         entry = calloc(1, sizeof(WasmExportEntry));
 
         SAFE_READ(ReadVarUInt32(ptr, &field_len, REMAINING_SIZE()));
-        entry->field = calloc(1, field_len + 1);
+        /* Prevent integer overflow when calculating allocation size */
+        size_t alloc_size = (size_t) field_len + 1;
+        if (alloc_size <= field_len) goto parse_error;
+        entry->field = calloc(1, alloc_size);
+        if (entry->field == NULL) goto parse_error;
 
         if (((ptr + field_len) - buffer) > buffer_size)
             goto parse_error;


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in lib/libwasm.c.

It is CWE-190: Integer Overflow or Wraparound that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix prevents integer overflow when calculating memory allocation size by casting to &quot;size_t&quot; and validating that adding 1 doesn’t wrap around, ensuring safe allocation and mitigating overflow-related vulnerabilities.<br>- Cast &quot;field_len&quot; to &quot;size_t&quot; before adding 1 to avoid overflow in pointer-size arithmetic: &quot;size_t alloc_size = (size_t) field_len + 1;&quot;.<br>- Verify no wraparound by checking &quot;alloc_size &lt;= field_len&quot;; if true, jump to error handling to prevent unsafe allocation.<br>- Replace original allocation with &quot;calloc(1, alloc_size)&quot;, ensuring correct memory size is requested.<br>- Add a null check for the allocation result, jumping to &quot;parse_error&quot; if allocation fails, improving robustness.

### 💡 Important Instructions
Ensure that <code>parse_error</code> handles cleanup correctly to prevent memory leaks or undefined behavior after this early exit.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/2b0f51b9-9bb1-42a8-8b45-3dce78c3a523)

