### PR TITLE
Fix for CWE-122: Heap-based Buffer Overflow

### DIFF
--- a/lib/libwasm.c
+++ b/lib/libwasm.c
@@ -363,10 +363,22 @@ int Wasm_ParseTypeSection(uint8_t* buffer, uint32_t buffer_size, WasmSection* se
     for (int i = 0; i < count; i++)
     {
         entry = calloc(1, sizeof(WasmFuncType));
-        entry->params = calloc(10, sizeof(WasmValueType)); // WebAssembly limits functions to 10 parameters.
 
         SAFE_READ(ReadVarInt7(ptr, &entry->form, REMAINING_SIZE()));
         SAFE_READ(ReadVarUInt32(ptr, &entry->param_count, REMAINING_SIZE()));
+/* Validate and allocate params according to declared param_count to prevent heap overflow */
+if (entry->param_count > 10)
+{
+    goto parse_error;
+}
+if (entry->param_count > 0)
+{
+    entry->params = calloc(entry->param_count, sizeof(WasmValueType));
+    if (entry->params == NULL)
+    {
+        goto parse_error;
+    }
+}
 
         if (entry->param_count > 0)
         {


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in lib/libwasm.c.

It is CWE-122: Heap-based Buffer Overflow that has a severity of :red_circle: Critical.

### 🪄 Fix explanation
The fix mitigates a heap overflow by validating the parameter count before allocation and dynamically allocating the params buffer only for the declared count, preventing overruns beyond the maximum limit of 10 parameters.<br>- Removed fixed-size allocation &quot;calloc(10, sizeof(WasmValueType))&quot;, which risked overflow if actual param_count was larger.<br>- Added a check &quot;if (entry-&gt;param_count &gt; 10) goto parse_error;&quot; to enforce WebAssembly’s maximum parameter limit.<br>- Allocated &quot;entry-&gt;params&quot; dynamically with size based on &quot;entry-&gt;param_count&quot; to fit exactly the required parameters.<br>- Added NULL check after allocation to handle memory failures safely, redirecting to &quot;parse_error&quot; if allocation fails.

### 💡 Important Instructions
Ensure that the <code>parse_error</code> label correctly frees any previously allocated resources to avoid memory leaks during error handling.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/f30cc540-a8b2-42c5-b152-a0e65496c673)

